### PR TITLE
Client is automatically closed once dropped

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -14,63 +14,73 @@ struct RequestIDMismatchError;
 impl Error for RequestIDMismatchError {}
 
 impl fmt::Display for RequestIDMismatchError {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "received error response from server")
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "received error response from server")
+    }
 }
 
 pub struct Client {
-	conn: TcpStream,
-	last_id: AtomicI32,
+    conn: TcpStream,
+    last_id: AtomicI32,
 }
 
 impl Client {
-	pub fn new(hostport: String) -> Result<Client, Box<dyn Error>> {
-		let conn = TcpStream::connect(hostport)?;
-		Ok(Client{
-			conn: conn,
-			last_id: AtomicI32::new(0),
-		})
-	}
+    pub fn new(hostport: String) -> Result<Client, Box<dyn Error>> {
+        let conn = TcpStream::connect(hostport)?;
+        Ok(Client {
+            conn: conn,
+            last_id: AtomicI32::new(0),
+        })
+    }
 
-	pub fn close(&mut self) -> Result<(), Box<dyn Error>> {
-		self.conn.shutdown(Shutdown::Both)?;
-		Ok(())
-	}
+    pub fn close(&mut self) -> Result<(), Box<dyn Error>> {
+        self.conn.shutdown(Shutdown::Both)?;
+        Ok(())
+    }
 
-	pub fn authenticate(&mut self, password: String) -> Result<message::Message, Box<dyn Error>> {
-		self.send_message(message::MessageType::Authenticate as i32, password)
-	}
+    pub fn authenticate(&mut self, password: String) -> Result<message::Message, Box<dyn Error>> {
+        self.send_message(message::MessageType::Authenticate as i32, password)
+    }
 
-	pub fn send_command(&mut self, command: String) -> Result<message::Message, Box<dyn Error>> {
-		self.send_message(message::MessageType::Command as i32, command)
-	}
+    pub fn send_command(&mut self, command: String) -> Result<message::Message, Box<dyn Error>> {
+        self.send_message(message::MessageType::Command as i32, command)
+    }
 
-	fn next_id(&self) -> i32 {
-		let prev = self.last_id.load(Ordering::Relaxed);
-		let next = prev + 1;
-		self.last_id.store(next, Ordering::Relaxed);
-		next
-	}
+    fn next_id(&self) -> i32 {
+        let prev = self.last_id.load(Ordering::Relaxed);
+        let next = prev + 1;
+        self.last_id.store(next, Ordering::Relaxed);
+        next
+    }
 
-	fn send_message(&mut self, msg_type: i32, msg_body: String) -> Result<message::Message, Box<dyn Error>> {
-		let req_id = self.next_id();
-		let req = message::Message{
-			size: msg_body.len() as i32 + message::HEADER_SIZE,
-			id: req_id.clone(),
-			msg_type: msg_type,
-			body: msg_body,
-		};
+    fn send_message(
+        &mut self,
+        msg_type: i32,
+        msg_body: String,
+    ) -> Result<message::Message, Box<dyn Error>> {
+        let req_id = self.next_id();
+        let req = message::Message {
+            size: msg_body.len() as i32 + message::HEADER_SIZE,
+            id: req_id.clone(),
+            msg_type: msg_type,
+            body: msg_body,
+        };
 
-		self.conn.write_all(&message::encode_message(req)[..])?;
-		let mut resp_bytes = [0u8; MAX_MESSAGE_SIZE];
-		self.conn.read(&mut resp_bytes)?;
-		let resp = message::decode_message(resp_bytes.to_vec())?;
+        self.conn.write_all(&message::encode_message(req)[..])?;
+        let mut resp_bytes = [0u8; MAX_MESSAGE_SIZE];
+        self.conn.read(&mut resp_bytes)?;
+        let resp = message::decode_message(resp_bytes.to_vec())?;
 
-		if req_id == resp.id {
-			Ok(resp)
-		} else {
-			Err(Box::new(RequestIDMismatchError))
-		}
-	}
+        if req_id == resp.id {
+            Ok(resp)
+        } else {
+            Err(Box::new(RequestIDMismatchError))
+        }
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        _ = self.close();
+    }
 }


### PR DESCRIPTION
I've implemented Drop for Client such that on once going out of scope and being dropped, it will first run the .close() method, the only caveat is that the result of closing the connection isn't handled - I don't know if there is a solution for this, but it probably doesn't matter.