### PR TITLE
fix: handle fragmented RCON responses and add read timeout

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -27,8 +27,9 @@ pub struct Client {
 impl Client {
     pub fn new(hostport: String) -> Result<Client, Box<dyn Error>> {
         let conn = TcpStream::connect(hostport)?;
+        conn.set_read_timeout(Some(std::time::Duration::from_millis(500)))?;
         Ok(Client {
-            conn: conn,
+            conn,
             last_id: AtomicI32::new(0),
         })
     }
@@ -39,11 +40,44 @@ impl Client {
     }
 
     pub fn authenticate(&mut self, password: String) -> Result<message::Message, Box<dyn Error>> {
-        self.send_message(message::MessageType::Authenticate as i32, password)
+        let resp = self.send_message(message::MessageType::Authenticate as i32, password)?;
+        println!("{resp:?}");
+        // Drain any extra response Minecraft sends after auth
+        let mut drain = [0u8; MAX_MESSAGE_SIZE];
+        let _ = self.conn.read(&mut drain);
+        Ok(resp)
     }
 
     pub fn send_command(&mut self, command: String) -> Result<message::Message, Box<dyn Error>> {
-        self.send_message(message::MessageType::Command as i32, command)
+        let req_id = self.next_id();
+        let req = message::Message {
+            size: command.len() as i32 + message::HEADER_SIZE,
+            id: req_id.clone(),
+            msg_type: message::MessageType::Command as i32,
+            body: command,
+        };
+
+        self.conn.write_all(&message::encode_message(req)[..])?;
+
+        let mut full_body = String::new();
+        let mut last_resp: Option<message::Message> = None;
+
+        loop {
+            let mut resp_bytes = [0u8; MAX_MESSAGE_SIZE];
+            match self.conn.read(&mut resp_bytes) {
+                Ok(_) => {
+                    let resp = message::decode_message(resp_bytes.to_vec())?;
+                    full_body.push_str(&resp.body);
+                    last_resp = Some(resp);
+                },
+                Err(_) => break,
+            }
+        }
+
+        match last_resp {
+            Some(mut r) => { r.body = full_body; Ok(r) },
+            None => Err(Box::new(RequestIDMismatchError)),
+        }
     }
 
     fn next_id(&self) -> i32 {
@@ -74,6 +108,7 @@ impl Client {
         if req_id == resp.id {
             Ok(resp)
         } else {
+            eprintln!("ID mismatch: sent {}, got {}", req_id, resp.id);
             Err(Box::new(RequestIDMismatchError))
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,7 +41,6 @@ impl Client {
 
     pub fn authenticate(&mut self, password: String) -> Result<message::Message, Box<dyn Error>> {
         let resp = self.send_message(message::MessageType::Authenticate as i32, password)?;
-        println!("{resp:?}");
         // Drain any extra response Minecraft sends after auth
         let mut drain = [0u8; MAX_MESSAGE_SIZE];
         let _ = self.conn.read(&mut drain);
@@ -108,7 +107,6 @@ impl Client {
         if req_id == resp.id {
             Ok(resp)
         } else {
-            eprintln!("ID mismatch: sent {}, got {}", req_id, resp.id);
             Err(Box::new(RequestIDMismatchError))
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -40,7 +40,9 @@ pub fn decode_message(bytes: Vec<u8>) -> Result<Message, Box<dyn Error>> {
 	let mut body = "".to_string();
 	let body_len: usize = (size - HEADER_SIZE).try_into()?;
 	if body_len > 0 {
-		let body_bytes = from_utf8(&bytes[12..12+body_len])?;
+		let available = bytes.len().saturating_sub(12);
+		let safe_len = body_len.min(available);
+		let body_bytes = from_utf8(&bytes[12..12+safe_len])?;
 		body = body_bytes.to_string();
 	}
 


### PR DESCRIPTION
Fixed ID mismatch errors caused by fragmented RCON responses. Added read timeout to avoid blocking indefinitely and accumulate body across multiple packets.